### PR TITLE
Update homepage property with .github.io domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/continuouscalendar/dateutils/issues"
   },
   "main": "./build/dateutils-latest.js",
-  "homepage": "http://continuouscalendar.github.com/dateutils/",
+  "homepage": "http://continuouscalendar.github.io/dateutils/",
   "files": [
     "src",
     "package.json",


### PR DESCRIPTION
homepage link had a deprecated top level domain - same thing for the link in the GH repo About section